### PR TITLE
Copy cookies to the request

### DIFF
--- a/testdata/request-get.json
+++ b/testdata/request-get.json
@@ -1,11 +1,11 @@
 {
   "version": "2.0",
   "routeKey": "$default",
-  "rawPath": "/dev",
+  "rawPath": "/dev/abc",
   "rawQueryString": "",
   "headers": {
     "accept": "*/*",
-    "content-length": "0",
+    "content-length": "4",
     "host": "v6rlfj8f7b.execute-api.us-west-2.amazonaws.com",
     "user-agent": "curl/7.64.1",
     "x-amzn-trace-id": "Root=1-5e7ba409-cfd1f29e556a912cd7c4e768",
@@ -13,6 +13,10 @@
     "x-forwarded-port": "443",
     "x-forwarded-proto": "https"
   },
+  "cookies": [
+    "abc=123",
+    "def=456"
+  ],
   "requestContext": {
     "accountId": "850443897857",
     "apiId": "v6rlfj8f7b",
@@ -20,7 +24,7 @@
     "domainPrefix": "v6rlfj8f7b",
     "http": {
       "method": "GET",
-      "path": "/dev",
+      "path": "/dev/abc",
       "protocol": "HTTP/1.1",
       "sourceIp": "73.189.109.118",
       "userAgent": "curl/7.64.1"

--- a/wrapper.go
+++ b/wrapper.go
@@ -202,7 +202,20 @@ func makeV2Request(event Request, prefix string) (*http.Request, error) {
 		return nil, fmt.Errorf("unable to create request: %w", err)
 	}
 
+	var contentLength int64
+	if s, ok := event.Headers["content-length"]; ok {
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse content length, %v: %w", s, err)
+		}
+		contentLength = v
+	}
+
 	setHeader(event, req)
+
+	req.ContentLength = contentLength
+	req.RemoteAddr = event.Headers["x-forwarded-for"]
+	req.RequestURI = stripPrefix(event.RawPath, prefix)
 
 	return req, nil
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -35,6 +35,7 @@ type RequestContext struct {
 }
 
 type Request struct {
+	Cookies         []string          `json:"cookies,omitempty"`
 	Version         string            `json:"version,omitempty"`
 	RouteKey        string            `json:"routeKey,omitempty"`
 	RawPath         string            `json:"rawPath,omitempty"`
@@ -103,6 +104,7 @@ func setHeader(event Request, req *http.Request) {
 		}
 		req.Header.Set(k, v)
 	}
+	req.Header.Add("Cookie", strings.Join(event.Cookies, ";"))
 }
 
 func makeBody(body string, isBase64Encoded bool) (io.Reader, error) {

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -17,6 +17,53 @@ func TestNewRequest(t *testing.T) {
 	}
 }
 
+func Test_makeV2Request(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/request-get.json")
+	if err != nil {
+		t.Fatalf("got %v; want nil", err)
+	}
+
+	var event Request
+	err = json.Unmarshal(data, &event)
+	if err != nil {
+		t.Fatalf("got %v; want nil", err)
+	}
+
+	req, err := makeV2Request(event, "/dev")
+	if err != nil {
+		t.Fatalf("got %v; want nil", err)
+	}
+
+	if want, got := "v6rlfj8f7b.execute-api.us-west-2.amazonaws.com", req.Host; got != want {
+		t.Fatalf("got %v; want %v", got, want)
+	}
+	if want, got := "73.189.109.118", req.RemoteAddr; got != want {
+		t.Fatalf("got %v; want %v", got, want)
+	}
+	if want, got := "/abc", req.URL.Path; got != want {
+		t.Fatalf("got %v; want %v", got, want)
+	}
+	if want, got := "/abc", req.RequestURI; got != want {
+		t.Fatalf("got %v; want %v", got, want)
+	}
+	if want, got := int64(4), req.ContentLength; got != want {
+		t.Fatalf("got %v; want %v", got, want)
+	}
+	if want, got := http.MethodGet, req.Method; got != want {
+		t.Fatalf("got %v; want %v", got, want)
+	}
+	if want, got := "/abc", req.URL.Path; got != want {
+		t.Fatalf("got %v; want %v", got, want)
+	}
+	got, err := req.Cookie("abc")
+	if err != nil {
+		t.Fatalf("got %v; want nil", err)
+	}
+	if want := "123"; want != got.Value {
+		t.Fatalf("got %v; want %v; err %v", got, want, err)
+	}
+}
+
 func Test_makeV1Request(t *testing.T) {
 	data, err := ioutil.ReadFile("testdata/request-v1-post.json")
 	if err != nil {


### PR DESCRIPTION
In the v2 format, cookies are represented separate from headers, as per https://medium.com/@lancers/amazon-api-gateway-explaining-lambda-payload-version-2-0-in-http-api-24b0b4db5d36; So, we make sure we copy them over so that session-based backends continue to work